### PR TITLE
poc of fixing esbuild problem with es5 target

### DIFF
--- a/src/configHelper.ts
+++ b/src/configHelper.ts
@@ -11,6 +11,9 @@ export const loadProjectConfigFile = async (
     config?: unknown;
   }>({
     filepath: configFilepath,
+    esbuildOptions: {
+      logLevel: 'silent',
+    },
   });
 
   return mod?.default ?? mod?.config ?? mod;
@@ -18,7 +21,7 @@ export const loadProjectConfigFile = async (
 
 let tsNodeService: Service;
 
-export const setupTsNode = async (): Promise<Service> => {
+const setupTsNode = async (): Promise<Service> => {
   if (tsNodeService) {
     return tsNodeService;
   }
@@ -42,12 +45,10 @@ export const setupTsNode = async (): Promise<Service> => {
         'config',
         `Please install "ts-node" to use a TypeScript configuration file`,
       );
-      // @ts-expect-error Error type definition is missing 'message'
-      log(error.message);
       process.exit(1);
     }
 
-    throw error;
+    process.exit(1);
   }
 };
 

--- a/src/configHelper.ts
+++ b/src/configHelper.ts
@@ -1,5 +1,8 @@
 import { bundleRequire } from 'bundle-require';
 
+import type { Service } from 'ts-node';
+import { log } from './log';
+
 export const loadProjectConfigFile = async (
   configFilepath: string,
 ): Promise<unknown> => {
@@ -11,4 +14,53 @@ export const loadProjectConfigFile = async (
   });
 
   return mod?.default ?? mod?.config ?? mod;
+};
+
+let tsNodeService: Service;
+
+export const setupTsNode = async (): Promise<Service> => {
+  if (tsNodeService) {
+    return tsNodeService;
+  }
+
+  try {
+    const tsNode = await import('ts-node');
+
+    tsNodeService = tsNode.register({
+      transpileOnly: true,
+      compilerOptions: {
+        module: 'commonjs',
+      },
+    });
+
+    return tsNodeService;
+  } catch (error: unknown) {
+    // @ts-expect-error Error type definition is missing 'code'
+    if (['ERR_MODULE_NOT_FOUND', 'MODULE_NOT_FOUND'].includes(error.code)) {
+      log.process(
+        'error',
+        'config',
+        `Please install "ts-node" to use a TypeScript configuration file`,
+      );
+      // @ts-expect-error Error type definition is missing 'message'
+      log(error.message);
+      process.exit(1);
+    }
+
+    throw error;
+  }
+};
+
+export const loadTSProjectConfigFile = async (
+  configFilepath: string,
+): Promise<unknown> => {
+  await setupTsNode();
+  tsNodeService.enabled(true);
+
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment
+  const imported: Record<string, unknown> = require(configFilepath);
+
+  tsNodeService.enabled(false);
+
+  return imported?.default ?? imported?.config;
 };


### PR DESCRIPTION
the only problem here is that we are still re-throwing errors from failed es5 transformation, would love to swallow them:

```
✘ [ERROR] Transforming const to the configured target environment ("es5") is not supported yet

    lostpixel.config.ts:1:233:
      1 │ ...pace/lost-pixel-next-storybook";const __injected_import_meta_url__ =...
        ╵                                    ~~~~~
```