### PR TITLE
Update npm package download count badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <h1>Lost Pixel</h1>
   <h2>Holistic visual regression testing solution </h2>  
   <a href="https://www.npmjs.com/package/lost-pixel"><img src="https://img.shields.io/npm/v/lost-pixel?style=plastic" /></a> 
-  <a href=https://www.npmjs.com/package/lost-pixel)><img src="https://img.shields.io/npm/dt/lost-pixel" /></a> 
+  <a href="https://www.npmjs.com/package/lost-pixel"><img src="https://img.shields.io/npm/dt/lost-pixel" /></a> 
   <a href="https://github.com/lost-pixel/lost-pixel/blob/main/docs/contributing.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" /></a>
   <a href="https://github.com/lost-pixel/lost-pixel/blob/main/LICENSE"><img src="https://img.shields.io/github/license/lost-pixel/lost-pixel" /></a>
   <a href="https://discord.gg/WqVjk49g9m"><img src="https://img.shields.io/badge/chat-discord-blue?style=flat&logo=discord" alt="discord chat"></a>


### PR DESCRIPTION
Updated the npm package download count badge to fix a broken link by adding a missing quotation mark in the anchor tag. 

The original code didn't have the href attribute enclosed within quotes properly. Clicking on the original badge resulted in the following page:
![image](https://user-images.githubusercontent.com/24467345/219931077-d5e9aee0-c990-4faf-a66c-25b6e2ae159b.png)


The badge now correctly links to the npm package page:
![image](https://user-images.githubusercontent.com/24467345/219931223-87edfb2b-559a-4cb8-b984-59def63acfbd.png)


 All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/lost-pixel/lost-pixel/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lost-pixel/lost-pixel/pulls) for the same update/change?
