### PR TITLE
fix(odiff): Normalize difference percentage before comparison

### DIFF
--- a/src/compare/compare.test.ts
+++ b/src/compare/compare.test.ts
@@ -157,17 +157,7 @@ describe(compareImagesViaPixelmatch, () => {
     expect(result1.isWithinThreshold).toBe(true);
     expect(result1.pixelDifference).toBeGreaterThan(50_000);
 
-    const result2 = await compareImagesViaPixelmatch(
-      400_000,
-      'fixtures/baseline/banner.png',
-      'fixtures/current/banner2.png',
-      'fixtures/test-results/banner2.png',
-    );
-
-    expect(result2.isWithinThreshold).toBe(true);
-    expect(result2.pixelDifference).toBeGreaterThan(350_000);
-
-    const result3 = await compareImagesViaPixelmatch(
+    const result3 = await compareImagesViaOdiff(
       50_000,
       'fixtures/baseline/banner.png',
       'fixtures/current/banner3.png',

--- a/src/compare/compare.test.ts
+++ b/src/compare/compare.test.ts
@@ -1,5 +1,9 @@
 import { existsSync, mkdirSync } from 'node:fs';
-import { checkThreshold, compareImagesViaPixelmatch } from './compare';
+import {
+  checkThreshold,
+  compareImagesViaPixelmatch,
+  compareImagesViaOdiff,
+} from './compare';
 
 beforeAll(() => {
   if (!existsSync('fixtures/test-results')) {
@@ -112,6 +116,38 @@ describe(compareImagesViaPixelmatch, () => {
 
   it('should accept differences in images within a given threshold', async () => {
     const result1 = await compareImagesViaPixelmatch(
+      0.4,
+      'fixtures/baseline/banner.png',
+      'fixtures/current/banner1.png',
+      'fixtures/test-results/banner1.png',
+    );
+
+    expect(result1.isWithinThreshold).toBe(true);
+    expect(result1.pixelDifference).toBeGreaterThan(50_000);
+
+    const result2 = await compareImagesViaPixelmatch(
+      400_000,
+      'fixtures/baseline/banner.png',
+      'fixtures/current/banner2.png',
+      'fixtures/test-results/banner2.png',
+    );
+
+    expect(result2.isWithinThreshold).toBe(true);
+    expect(result2.pixelDifference).toBeGreaterThan(350_000);
+
+    const result3 = await compareImagesViaPixelmatch(
+      50_000,
+      'fixtures/baseline/banner.png',
+      'fixtures/current/banner3.png',
+      'fixtures/test-results/banner3.png',
+    );
+
+    expect(result3.isWithinThreshold).toBe(true);
+    expect(result3.pixelDifference).toBeGreaterThan(40_000);
+  }, 12_000);
+
+  it('should accept differences in images within a given threshold if using odiff', async () => {
+    const result1 = await compareImagesViaOdiff(
       0.4,
       'fixtures/baseline/banner.png',
       'fixtures/current/banner1.png',

--- a/src/compare/compare.ts
+++ b/src/compare/compare.ts
@@ -98,7 +98,7 @@ export const compareImagesViaPixelmatch = async (
   };
 };
 
-const compareImagesViaOdiff = async (
+export const compareImagesViaOdiff = async (
   threshold: number,
   baselineShotPath: string,
   currentShotPath: string,
@@ -129,8 +129,10 @@ const compareImagesViaOdiff = async (
     let isWithinThreshold = true;
 
     // Treat theshold as percentage
+    const pixelDifferencePercentage = Number(result.diffPercentage / 100);
+
     if (threshold < 1) {
-      isWithinThreshold = result.diffPercentage <= threshold;
+      isWithinThreshold = pixelDifferencePercentage <= threshold;
     } else {
       // Treat threshold as absolute value
       isWithinThreshold = result.diffCount <= threshold;
@@ -138,7 +140,7 @@ const compareImagesViaOdiff = async (
 
     return {
       pixelDifference: Number(result.diffCount),
-      pixelDifferencePercentage: Number(result.diffPercentage / 100),
+      pixelDifferencePercentage,
       isWithinThreshold,
     };
   }


### PR DESCRIPTION
 All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/lost-pixel/lost-pixel/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lost-pixel/lost-pixel/pulls) for the same update/change?

Closes #289 
Basically normalize the diffPercentage before comparing with the threshold

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?