### PR TITLE
Feat/extend ladle story options

### DIFF
--- a/examples/example-ladle/src/storyname.stories.tsx
+++ b/examples/example-ladle/src/storyname.stories.tsx
@@ -1,12 +1,12 @@
 export const Cat = () => {
-  const Stop = { storyName: "" };
+  const Stop = { storyName: '' };
   // should be ignored
-  Stop.storyName = "What";
+  Stop.storyName = 'What';
   return <h1>Cat</h1>;
 };
 
-Cat.storyName = "Doggo";
-Cat.foo = "Ha";
+Cat.storyName = 'Doggo';
+Cat.foo = 'Ha';
 
 export const CapitalCity = () => {
   return <h1>DC</h1>;
@@ -15,4 +15,14 @@ export const CapitalCity = () => {
 export const CapitalReplaced = () => {
   return <h1>CapitalReplaced</h1>;
 };
-CapitalReplaced.storyName = "Champs Élysées";
+CapitalReplaced.storyName = 'Champs Élysées';
+
+export const DisabledStory = () => {
+  return <h1>DisabledStory</h1>;
+};
+DisabledStory.storyName = 'DisabledStory';
+DisabledStory.meta = {
+  lostpixel: {
+    disabled: true,
+  },
+};

--- a/examples/example-ladle/src/storyname.stories.tsx
+++ b/examples/example-ladle/src/storyname.stories.tsx
@@ -23,6 +23,6 @@ export const DisabledStory = () => {
 DisabledStory.storyName = 'DisabledStory';
 DisabledStory.meta = {
   lostpixel: {
-    disabled: true,
+    disable: true,
   },
 };

--- a/src/crawler/ladleScreenshots.ts
+++ b/src/crawler/ladleScreenshots.ts
@@ -23,50 +23,25 @@ export const generateLadleShotItems = (
 ): ShotItem[] => {
   const ladleUrl = isLocalServer ? `${baseUrl}/index.html` : baseUrl;
 
-  return ladleStories.flatMap((ladleStory): ShotItem[] => {
-    const shotName =
-      config.shotNameGenerator?.({ ...ladleStory, shotMode: 'ladle' }) ??
-      ladleStory.id;
-    let label = generateLabel({ browser });
-    let fileNameWithExt = `${shotName}${label}.png`;
+  return ladleStories
+    .filter((story) => story.parameters?.lostpixel?.disable !== true)
+    .filter((story) =>
+      config.filterShot
+        ? config.filterShot({ ...story, shotMode: 'ladle' })
+        : true,
+    )
+    .flatMap((ladleStory): ShotItem[] => {
+      const shotName =
+        config.shotNameGenerator?.({ ...ladleStory, shotMode: 'ladle' }) ??
+        ladleStory.id;
+      let label = generateLabel({ browser });
+      let fileNameWithExt = `${shotName}${label}.png`;
 
-    const shotItem: ShotItem = {
-      shotMode: 'ladle',
-      id: `${ladleStory.story}${label}`,
-      shotName: `${shotName}${label}`,
-      url: `${ladleUrl}?story=${ladleStory.story}&mode=preview`,
-      filePathBaseline: isPlatformModeConfig(config)
-        ? notSupported
-        : path.join(config.imagePathBaseline, fileNameWithExt),
-      filePathCurrent: path.join(config.imagePathCurrent, fileNameWithExt),
-      filePathDifference: isPlatformModeConfig(config)
-        ? notSupported
-        : path.join(config.imagePathDifference, fileNameWithExt),
-      threshold: config.threshold,
-      mask: mask ?? [],
-    };
-
-    const breakpoints = selectBreakpoints(
-      config.breakpoints,
-      modeBreakpoints,
-      ladleStory.parameters?.lostpixel?.breakpoints,
-    );
-
-    if (breakpoints.length === 0) {
-      return [shotItem];
-    }
-
-    return breakpoints.map((breakpoint) => {
-      label = generateLabel({ breakpoint, browser });
-      fileNameWithExt = `${shotName}${label}.png`;
-
-      return {
-        ...shotItem,
+      const shotItem: ShotItem = {
+        shotMode: 'ladle',
         id: `${ladleStory.story}${label}`,
-        shotName: `${ladleStory.story}${label}`,
-        breakpoint,
-        breakpointGroup: ladleStory.story,
-        url: `${ladleUrl}?story=${ladleStory.story}&mode=preview&width=${breakpoint}`,
+        shotName: `${shotName}${label}`,
+        url: `${ladleUrl}?story=${ladleStory.story}&mode=preview`,
         filePathBaseline: isPlatformModeConfig(config)
           ? notSupported
           : path.join(config.imagePathBaseline, fileNameWithExt),
@@ -74,10 +49,42 @@ export const generateLadleShotItems = (
         filePathDifference: isPlatformModeConfig(config)
           ? notSupported
           : path.join(config.imagePathDifference, fileNameWithExt),
-        viewport: { width: breakpoint },
+        threshold: config.threshold,
+        mask: mask ?? [],
       };
+
+      const breakpoints = selectBreakpoints(
+        config.breakpoints,
+        modeBreakpoints,
+        ladleStory.parameters?.lostpixel?.breakpoints,
+      );
+
+      if (breakpoints.length === 0) {
+        return [shotItem];
+      }
+
+      return breakpoints.map((breakpoint) => {
+        label = generateLabel({ breakpoint, browser });
+        fileNameWithExt = `${shotName}${label}.png`;
+
+        return {
+          ...shotItem,
+          id: `${ladleStory.story}${label}`,
+          shotName: `${ladleStory.story}${label}`,
+          breakpoint,
+          breakpointGroup: ladleStory.story,
+          url: `${ladleUrl}?story=${ladleStory.story}&mode=preview&width=${breakpoint}`,
+          filePathBaseline: isPlatformModeConfig(config)
+            ? notSupported
+            : path.join(config.imagePathBaseline, fileNameWithExt),
+          filePathCurrent: path.join(config.imagePathCurrent, fileNameWithExt),
+          filePathDifference: isPlatformModeConfig(config)
+            ? notSupported
+            : path.join(config.imagePathDifference, fileNameWithExt),
+          viewport: { width: breakpoint },
+        };
+      });
     });
-  });
 };
 
 export const collectLadleStories = async (ladleUrl: string) => {

--- a/src/crawler/ladleScreenshots.ts
+++ b/src/crawler/ladleScreenshots.ts
@@ -41,6 +41,7 @@ export const generateLadleShotItems = (
         shotMode: 'ladle',
         id: `${ladleStory.story}${label}`,
         shotName: `${shotName}${label}`,
+        importPath: ladleStory.importPath,
         url: `${ladleUrl}?story=${ladleStory.story}&mode=preview`,
         filePathBaseline: isPlatformModeConfig(config)
           ? notSupported
@@ -103,6 +104,7 @@ export const collectLadleStories = async (ladleUrl: string) => {
       id: key,
       story: key,
       kind: key,
+      importPath: storyConfig.filePath,
       parameters: storyConfig.meta,
     });
   }

--- a/src/crawler/ladleScreenshots.ts
+++ b/src/crawler/ladleScreenshots.ts
@@ -50,8 +50,19 @@ export const generateLadleShotItems = (
         filePathDifference: isPlatformModeConfig(config)
           ? notSupported
           : path.join(config.imagePathDifference, fileNameWithExt),
-        threshold: config.threshold,
-        mask: mask ?? [],
+        threshold:
+          ladleStory.parameters?.lostpixel?.threshold ?? config.threshold,
+        waitBeforeScreenshot:
+          ladleStory.parameters?.lostpixel?.waitBeforeScreenshot ??
+          config.waitBeforeScreenshot,
+        mask: [
+          ...(mask ?? []),
+          ...(ladleStory.parameters?.lostpixel?.mask ?? []),
+        ],
+        elementLocator:
+          ladleStory.parameters?.lostpixel?.elementLocator ??
+          config?.storybookShots?.elementLocator ??
+          '',
       };
 
       const breakpoints = selectBreakpoints(

--- a/src/crawler/ladleScreenshots.ts
+++ b/src/crawler/ladleScreenshots.ts
@@ -7,6 +7,12 @@ import { selectBreakpoints, generateLabel } from '../shots/utils';
 import { notSupported } from '../constants';
 import type { Story } from './storybook';
 
+type LadleStoryConfig = {
+  name: string;
+  filePath: string;
+  meta: Record<string, unknown>;
+};
+
 export const generateLadleShotItems = (
   baseUrl: string,
   isLocalServer: boolean,
@@ -76,18 +82,23 @@ export const generateLadleShotItems = (
 
 export const collectLadleStories = async (ladleUrl: string) => {
   const {
-    data: ladleMeta,
+    data,
   }: {
     data: {
-      stories: {
-        id: string;
-      };
+      stories: LadleStoryConfig[];
     };
   } = await axios.get(`${ladleUrl}/meta.json`);
 
-  const collection: Story[] | undefined = Object.keys(ladleMeta.stories).map(
-    (storyKey) => ({ id: storyKey, story: storyKey, kind: storyKey }),
-  );
+  const collection: Story[] = [];
+
+  for (const [key, storyConfig] of Object.entries(data.stories)) {
+    collection.push({
+      id: key,
+      story: key,
+      kind: key,
+      parameters: storyConfig.meta,
+    });
+  }
 
   return collection;
 };

--- a/src/shots/shots.ts
+++ b/src/shots/shots.ts
@@ -75,6 +75,19 @@ const takeScreenShot = async ({
     );
   }
 
+  if (shotItem.shotMode === 'ladle') {
+    try {
+      await page.waitForSelector('[data-storyloaded]');
+    } catch (error: unknown) {
+      logger.process(
+        'error',
+        'timeout',
+        `Timeout while waiting for Ladle story to load: ${shotItem.url}`,
+        error,
+      );
+    }
+  }
+
   try {
     await waitForNetworkRequests({
       page,


### PR DESCRIPTION
provide new options for Ladle on shot level via `meta`:
- disable
- threshold
- waitBeforeScreenshot
- mask
- elementLocator

example: 
```ts
export const DisabledStory = () => {
  return <h1>DisabledStory</h1>;
};
DisabledStory.storyName = 'DisabledStory';
DisabledStory.meta = {
  lostpixel: {
    disable: true,
  },
};
```