### PR TITLE
Update serve-handler from 6.1.5 to 6.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "playwright-core": "1.47.2",
         "pngjs": "7.0.0",
         "posthog-node": "3.5.0",
-        "serve-handler": "6.1.5",
+        "serve-handler": "6.1.6",
         "shelljs": "0.8.5",
         "ts-node": "10.9.2",
         "xml2js": "^0.6.2",
@@ -5346,15 +5346,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-url-parser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
-      "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^1.3.2"
-      }
-    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -9004,10 +8995,9 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
-      "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==",
-      "license": "MIT"
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -9365,12 +9355,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
-    },
-    "node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "license": "MIT"
     },
     "node_modules/pure-rand": {
@@ -9929,18 +9913,16 @@
       }
     },
     "node_modules/serve-handler": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.5.tgz",
-      "integrity": "sha512-ijPFle6Hwe8zfmBxJdE+5fta53fdIY0lHISJvuikXB3VYFafRjMRpOffSPvCYsbKyBA7pvy9oYr/BT1O3EArlg==",
-      "license": "MIT",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.6.tgz",
+      "integrity": "sha512-x5RL9Y2p5+Sh3D38Fh9i/iQ5ZK+e4xuXRd/pGbM4D13tgo/MGwbttUk8emytcr1YYzBYs+apnUngBDFYfpjPuQ==",
       "dependencies": {
         "bytes": "3.0.0",
         "content-disposition": "0.5.2",
-        "fast-url-parser": "1.1.3",
         "mime-types": "2.1.18",
         "minimatch": "3.1.2",
         "path-is-inside": "1.0.2",
-        "path-to-regexp": "2.2.1",
+        "path-to-regexp": "3.3.0",
         "range-parser": "1.2.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "playwright-core": "1.47.2",
     "pngjs": "7.0.0",
     "posthog-node": "3.5.0",
-    "serve-handler": "6.1.5",
+    "serve-handler": "6.1.6",
     "shelljs": "0.8.5",
     "ts-node": "10.9.2",
     "xml2js": "^0.6.2",


### PR DESCRIPTION
The updated server-handler updates the `path-to-regexp` dependency, which had a serious bug ([CVE-2024-45296](https://github.com/advisories/GHSA-9wv6-86v2-598j). While it is something unlikely to be causing production risk while using lost-pixel, it is certainly very annoying to get security warnings from Github in projects using lost-pixel.