### PR TITLE
fix: Windows compatibilty for docker mode

### DIFF
--- a/src/docker-runner/utils.ts
+++ b/src/docker-runner/utils.ts
@@ -20,8 +20,8 @@ export const executeDockerRun = async ({ version }: { version: string }) => {
     '--rm',
     // TODO: remove interactive mode for now, while it clashes with Tauri execution
     // '-it',
-    `-v ${process.cwd()}:${process.cwd()}`,
-    `-e WORKSPACE=${process.cwd()}`,
+    `-v ${process.cwd()}:/src`,
+    `-e WORKSPACE=/src`,
     '-e DOCKER=1',
     `-e LOST_PIXEL_DISABLE_TELEMETRY=${process.env.LOST_PIXEL_DISABLE_TELEMETRY}`,
     argv.configDir ? `-e LOST_PIXEL_CONFIG_DIR=${argv.configDir}` : '',


### PR DESCRIPTION
fix for #383 

sets the workspace mount point to a static path in the container, so lost-pixel can be run in docker mode on windows