### PR TITLE
refactor: utils story render completed

### DIFF
--- a/src/crawler/storybook.ts
+++ b/src/crawler/storybook.ts
@@ -50,6 +50,10 @@ export type Story = {
 type StorybookPreviewApi = {
   ready: () => Promise<void>;
   extract?: () => Promise<Record<string, Story>>;
+  channel?: {
+    on: (event: string, callback: (...args: any[]) => void) => void;
+    off: (event: string, callback: (...args: any[]) => void) => void;
+   }
 };
 
 type StorybookClientApi = {
@@ -124,7 +128,17 @@ export const collectStoriesViaWindowApi = async (
     await page.evaluate(async () => {
       const { __STORYBOOK_PREVIEW__: api } = window as WindowObject;
 
-      if (api.ready) {
+      if (api.channel) {
+        await new Promise((resolve) => {
+          const onStoryRenderPhaseChanged = (event: { newPhase: string }) => {
+            if (event.newPhase === 'completed') {
+              api.channel?.off('storyRenderPhaseChanged', onStoryRenderPhaseChanged);
+              resolve(true);
+            }
+          };
+          api.channel?.on('storyRenderPhaseChanged', onStoryRenderPhaseChanged);
+        });
+      } else if (api.ready) {
         await api.ready();
       }
     });


### PR DESCRIPTION
When using the `async play()` function in Storybook **Interaction Tests**, you should wait for the play method to complete execution before generating snapshots.
This update delays the timing of snapshot creation by waiting for the `completed` phase event instead of the `ready` phase event.


 All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/lost-pixel/lost-pixel/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/lost-pixel/lost-pixel/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Was the new feature discussed with core maintainers?
2. [x] Does your submission pass tests?
3. [x] Have you lint your code locally before submission?
4. [ ] Does the change require an update in documentation? Have you updated the documentation in case it's true?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Does the change require an update in documentation? Have you updated the documentation in case it's true?